### PR TITLE
Fix “no function clause matching in Jokester.handle_info/2"

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,7 +22,7 @@ config :daily_dad_jokes, DailyDadJokes.Repo,
   pool_size: 10
 
 # Do not print debug messages in production
-config :logger, level: :info
+config :logger, level: :debug
 
 # ## SSL Support
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,5 +21,5 @@ config :daily_dad_jokes, DailyDadJokesWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger,
-  level: :debug,
+  level: :warn,
   handle_sasl_reports: false


### PR DESCRIPTION
`:setup_joke_of_the_day` was only handled in a `handle_continue` but was also being sent as a `handle_info` message. Add `handle_info` handler and refactor setup into private function.